### PR TITLE
[MV-173] Add online docs

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - add_docs
 
 jobs:
   build:

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
 
       - name: Build Docs
-        run: xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
+        run: mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
 
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -17,7 +17,7 @@ jobs:
         run: brew install coreutils
 
       - name: Build Docs
-        run: alias cp=gcp && mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
+        run: echo "alias cp=gcp" >> ~/.bashrc && mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
 
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,0 +1,25 @@
+
+name: Deploy Docs
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - add_docs
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Docs
+        run: xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
+
+      - name: Deploy
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: gh-pages
+          FOLDER: MembraneRTC/docs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install coreutils
+        run: gcp
+
       - name: Build Docs
         run: mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
 

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install coreutils
-        run: gcp
+        run: brew install coreutils
 
       - name: Build Docs
-        run: mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
+        run: alias cp=gcp && mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
 
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -13,11 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Build Docs
+        run: mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
+
       - name: Install coreutils
         run: brew install coreutils
-
-      - name: Build Docs
-        run: echo "alias cp=gcp" >> ~/.bashrc && mkdir MembraneRTC/docs && xcodebuild docbuild -scheme MembraneRTC -destination generic/platform=iOS OTHER_DOCC_FLAGS="--transform-for-static-hosting --output-path docs --hosting-base-path membrane-webrtc-ios"
+      
+      - name: Change PATH
+        run: echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
 
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *xcdebugger
 .DS_Store
 node_modules
+build
+docs

--- a/MembraneRTC/Sources/Documentation.docc/MembraneRTC.md
+++ b/MembraneRTC/Sources/Documentation.docc/MembraneRTC.md
@@ -1,0 +1,23 @@
+# ``MembraneRTC``
+
+MembraneRTC client.
+
+The client is responsible for relaying MembraneRTC Engine specific messages through given reliable transport layer.
+Once initialized, the client is responsbile for exchaning necessary messages via provided `EventTransport` and managing underlying
+`RTCPeerConnection`. The goal of the client is to be as lean as possible, meaning that all activies regarding the session such as moderating
+should be implemented by the user himself on top of the `MembraneRTC`.
+
+The user's ability of interacting with the client is greatly liimited to the essential actions such as joining/leaving the session,
+adding/removing local tracks and receiving information about remote peers and their tracks that can be played by the user.
+
+User can request 3 different types of local tracks that will get forwareded to the server by the client:
+- `LocalAudioTrack` - an audio track utilizing device's microphone
+- `LocalVideoTrack` - a video track that can utilize device's camera or if necessay use video playback from a file (useful for testing with a simulator)
+- `LocalBroadcastScreenTrack` - a screencast track taking advantage of `Broadcast Upload Extension` to record device's screen even if the app is minimized
+
+It is recommended to request necessary audio and video tracks before joining the room but it does not mean it can't be done afterwards (in case of screencast)
+
+Once the user received `onConnected` notification they can call the `join` method to initialize joining the session.
+After receiving `onJoinSuccess` a user will receive notification about various peers joining/leaving the session, new tracks being published and ready for playback
+or going inactive.
+

--- a/MembraneRTC/Sources/MembraneRTC/Types/Encoder.swift
+++ b/MembraneRTC/Sources/MembraneRTC/Types/Encoder.swift
@@ -8,7 +8,7 @@ public enum Encoder {
     case H264
 }
 
-public func getEncoderFactory(from: Encoder) -> RTCVideoEncoderFactory {
+func getEncoderFactory(from: Encoder) -> RTCVideoEncoderFactory {
     switch from {
     case .DEFAULT:
         return RTCDefaultVideoEncoderFactory()

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The server then can capture and deserialize the packets which will get forwarded
 *IMPORTANT*
 Both extensnion and application must share the same App Group so that a proper CFMessagePort can get created.
 
+## Documentation
+API documentation is available [here](https://docs.membrane.stream/membrane-webrtc-ios/documentation/membranertc/).
 
 ## Necessary setup
 For the application to work properly one must set necessary constants inside 


### PR DESCRIPTION
Docs available on: https://docs.membrane.stream/membrane-webrtc-ios/documentation/membranertc/

I don't know if it's possible to have ios documentation on https://docs.membrane.stream/membrane-webrtc-ios/, docc documentation didn't cover that, even [here](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/publishing-to-github-pages/) the url has `documentation/module` part. If it's a problem I can investigate that or use different documentation tool.